### PR TITLE
Fix MQTT payload fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ updates** Home Assistant sensor entities for them on the fly—no manual configu
 - **Auto-discovers Pulse Hubs** using the API  
 - **Creates & Updates** Home Assistant sensor entities **dynamically**  
 - **Polls most recent data** at a configurable interval
-- **Publishes MQTT discovery & states** on `pulse/<device_id>/<param_name>` topics
+- **Publishes MQTT discovery & states** on `pulseapp/<device_unique_id>/<param_name>` topics
 - **Supports a wide range of sensor types**
 - **Allows Home Assistant automations** to act on sensor readings
 - **Supports recording the state updates using the Home Assistant Recorder addon

--- a/pulse_sensors.py
+++ b/pulse_sensors.py
@@ -40,6 +40,9 @@ class PulseSensors(hass.Hass):
         # Mqtt is provided by a separate API. We can use it as a mixin in this class.
         # But the docs suggest instantiating API objects for what plugins one needs.
         self._queue_plugin = self.get_plugin_api("MQTT")
+        if not self._queue_plugin:
+            self.logger.error("🛑 MQTT plugin not loaded! Sensor updates disabled.")
+            return
 
         # Read update intervals from Home Assistant inputs
         update_interval = int(float(
@@ -218,7 +221,6 @@ class PulseSensors(hass.Hass):
                             "p": "binary_sensor",
                             "name": f"{hub.name} {hub.id}",
                             "unique_id": hub_unique_id,
-                            "stat_t": f"pulseapp/{hub_unique_id}/state",
                         }
                     }
                 }
@@ -259,7 +261,6 @@ class PulseSensors(hass.Hass):
                         "unique_id": comp_unique_id,
                         "object_id": comp_unique_id,
                         "unit_of_measurement": measurement.MeasuringUnit,
-                        "value_template": f"{{{{ value_json.{param_name} }}}}",
                         "device_class": device_class_enum.value if device_class_enum else None,
                         "stat_t": f"pulseapp/{device_unique_id}/{param_name}",
                     }
@@ -277,7 +278,6 @@ class PulseSensors(hass.Hass):
                         "via_device": hub_unique_id,
                     },
                     "cmps": components,
-                    "stat_t": f"pulseapp/{device_unique_id}/state",
                 }
                 device_config_topic = f"homeassistant/device/{device_unique_id}/config"
 


### PR DESCRIPTION
## Summary
- warn if MQTT plugin isn't loaded
- remove unused hub/device `stat_t`
- remove `value_template` from sensor components
- update MQTT topic docs in README

## Testing
- `python -m py_compile pulse_sensors.py pulse_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68466801f8188331a1a8ad3ff3617ea8